### PR TITLE
Feat migrate the fetching of servers of HONO RPC to FETCH and some small bugs fix

### DIFF
--- a/apps/web/app/(routes)/page.tsx
+++ b/apps/web/app/(routes)/page.tsx
@@ -6,31 +6,24 @@ import AllQuestions from "@/components/custom/all-questions";
 import { Suspense, useEffect, useState } from "react";
 import { popularTags } from "@/json/dummy";
 import { JoinCommunityBtn } from "@/components/custom/join.community.btn";
-import { hc } from 'hono/client'
 import { ServerType } from "@iflow/types";
-import type { ServerApiType } from "@iflow/api";
 
 export default function Home() {
   const [selectedTag, setSelectedTag] = useState("");
   const [servers, setServers] = useState<ServerType[]>([]);
   const [loading, setLoading] = useState(false);
 
-  // const API_ENDPOINT = process.env.NODE_ENV == "development" ? "https://api.indexflow.site/v1/bot/server" : "https://api.indexflow.site/v1/bot/server";
-  const API_ENDPOINT = process.env.NODE_ENV == "development" ? "http://localhost:3001/v1/bot/server" : "https://api.indexflow.site/v1/bot/server";
+  const API_ENDPOINT = process.env.NODE_ENV == "development" ? "https://api.indexflow.site/v1/bot/server/all" : "https://api.indexflow.site/v1/bot/server/all";
+  // const API_ENDPOINT = process.env.NODE_ENV == "development" ? "http://localhost:3001/v1/bot/server" : "https://api.indexflow.site/v1/bot/server";
 
   useEffect(() => {
-    const client = hc<ServerApiType>(API_ENDPOINT);
     async function fetchServers() {
       setLoading(true);
-      const res = await client.all.$get({ query: { cursor: "", take: 10 } });
-      if (res.status === 404) {
-        const err: { message: string; status: number } = await res.json();
-        setLoading(false);
-      } else if (res.ok) {
-        const data: { servers: ServerType[] } = await res.json();
-        setServers(data.servers);
-        setLoading(false);
-      }
+
+      const data = await fetch(API_ENDPOINT);
+      const response = await data.json();
+      setServers([...response?.servers, ...servers]);
+      setLoading(false);
     }
 
     if (servers.length === 0) {

--- a/apps/web/components/custom/join.community.btn.tsx
+++ b/apps/web/components/custom/join.community.btn.tsx
@@ -28,7 +28,6 @@ export function JoinCommunityBtn({ InvUrl }: { InvUrl: string }) {
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction><Link href={InvUrl}>Continue</Link></AlertDialogAction>
           <AlertDialogAction asChild>
             <Link href={InvUrl}>Continue</Link>
           </AlertDialogAction>

--- a/apps/web/components/custom/question-card.tsx
+++ b/apps/web/components/custom/question-card.tsx
@@ -30,7 +30,7 @@ const QuestionCard = React.forwardRef<HTMLDivElement, QuestionCardProps>(
         <Card className="overflow-hidden p-0">
           <CardContent className="p-4 sm:p-6">
             <div className="space-y-2 sm:space-y-3">
-              <Link href={`/questions/${question.id}`}>
+              <Link href={`/qs/${question.id}`}>
                 <h3 className="text-lg sm:text-xl font-semibold hover:text-primary hover:underline line-clamp-2">
                   {question.title}
                 </h3>


### PR DESCRIPTION
This pull request includes several changes to the `apps/web` project to update API endpoints, modify component behavior, and adjust routing paths. The most important changes include updating the API endpoint in the `Home` component, changing the `JoinCommunityBtn` component to use `asChild` for an action button, and modifying the routing path for question links in the `QuestionCard` component.

Updates to API endpoint and component behavior:

* [`apps/web/app/(routes)/page.tsx`](diffhunk://#diff-75404548cc8b31415a1e005a9ac411e1f388b0fbc7fab282867126eb267eb8cfL9-L34): Updated the API endpoint for fetching servers to include `/all` in the URL and refactored the `fetchServers` function to use the native `fetch` method instead of the `hc` client.

Component modifications:

* [`apps/web/components/custom/join.community.btn.tsx`](diffhunk://#diff-746e9dbed752435f76b18dd6209a0eb1a4c78f606b3c12b742be641d9f400deeL31): Changed the `JoinCommunityBtn` component to use `asChild` for the `AlertDialogAction` to ensure proper rendering of the `Link` component.
* [`apps/web/components/custom/question-card.tsx`](diffhunk://#diff-c383e9a3435559394acb3c8b1d67ac71ea9581c2ed29d372ff927e0269fa0dfbL33-R33): Updated the routing path for question links from `/questions/{id}` to `/qs/{id}` to shorten the URL.