### PR TITLE
Feat filter configuration server based on config

### DIFF
--- a/apps/web/context/content.context.tsx
+++ b/apps/web/context/content.context.tsx
@@ -36,18 +36,23 @@ export function ContentProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     async function fetchServers() {
       setContentLoading(true);
-      const data = await fetch(SERVER_API_ENDPOINT);
-      const configData = await fetch(CONFIG_SERVER_API_ENDPOINT);
-      const response = await data.json();
-      const configResponse = await configData.json();
-    
-      const serverIdSet = new Set(configResponse?.configs?.map((config: any) => config.server_id));
-      const finalData = await response.servers.filter((item: any) => serverIdSet.has(item.id));
-
-      if (response?.servers) {
-        setServers(finalData);
+      try {
+        const data = await fetch(SERVER_API_ENDPOINT);
+        const configData = await fetch(CONFIG_SERVER_API_ENDPOINT);
+        const response = await data.json();
+        const configResponse = await configData.json();
+       
+        const serverIdSet = new Set(configResponse?.configs?.map((config: any) => config.server_id));
+        const finalData = response?.servers?.filter((item: any) => serverIdSet.has(item.id)) || [];
+       
+        if (response?.servers) {
+          setServers(finalData);
+        }
+      } catch (error) {
+        console.error("Error fetching server data:", error);
+      } finally {
+        setContentLoading(false);
       }
-      setContentLoading(false);
     }
 
     if (servers.length === 0) {

--- a/apps/web/context/content.context.tsx
+++ b/apps/web/context/content.context.tsx
@@ -27,14 +27,25 @@ export function ContentProvider({ children }: { children: ReactNode }) {
     process.env.NODE_ENV == "development"
       ? "http://localhost:3001/v1/user/public"
       : "https://api.indexflow.site/v1/user/public";
+  const CONFIG_SERVER_API_ENDPOINT =
+    process.env.NODE_ENV == "development"
+      ? "http://localhost:3001/v1/bot/server/config/all"
+      : "https://api.indexflow.site/v1/bot/server/config/all";
+
 
   useEffect(() => {
     async function fetchServers() {
       setContentLoading(true);
       const data = await fetch(SERVER_API_ENDPOINT);
+      const configData = await fetch(CONFIG_SERVER_API_ENDPOINT);
       const response = await data.json();
+      const configResponse = await configData.json();
+    
+      const serverIdSet = new Set(configResponse?.configs?.map((config: any) => config.server_id));
+      const finalData = await response.servers.filter((item: any) => serverIdSet.has(item.id));
+
       if (response?.servers) {
-        setServers(response.servers);
+        setServers(finalData);
       }
       setContentLoading(false);
     }


### PR DESCRIPTION
This pull request introduces a new API endpoint for fetching server configurations and updates the logic for setting servers based on these configurations in the `ContentProvider` component.

Display the Fully configuration done server only

<img width="383" alt="image" src="https://github.com/user-attachments/assets/ec74ead9-b6bd-40cd-9853-6d52a5204d1c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the server list display by incorporating environment-specific configuration data for filtering. Users will now see only the relevant servers based on the active configuration, ensuring a more tailored and accurate view.
- **Bug Fixes**
  - Improved error handling during data fetching to provide better logging and user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->