### PR TITLE
Adjust max height for thread display and questions list for better UI

### DIFF
--- a/apps/web/app/(routes)/page.tsx
+++ b/apps/web/app/(routes)/page.tsx
@@ -70,7 +70,7 @@ export default function Home() {
                 </div>
                 <h2 className="text-xl font-bold">Active Threads</h2>
               </div>
-              <div className="space-y-3 overflow-y-auto h-[calc(100vh-55vh)] overflow-x-hidden scrollbar-none [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
+              <div className="space-y-3 overflow-y-auto max-h-[50vh] overflow-x-hidden scrollbar-none [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
                 {contentLoading ? (
                   // Skeleton loading state
                   Array.from({ length: 10 }).map((_, index) => (

--- a/apps/web/components/custom/all-questions.tsx
+++ b/apps/web/components/custom/all-questions.tsx
@@ -148,7 +148,7 @@ export default function QuestionsList({
         </div>
       </div>
 
-      <div className="space-y-4 relative h-full overflow-x-hidden scrollbar-none [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
+      <div className="space-y-4 relative h-screen md:h-[105vh] overflow-x-hidden scrollbar-none [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:'none']">
           {isLoading ? (
             // Show skeleton cards when loading
             Array.from({ length: 10 }).map((_, index) => (


### PR DESCRIPTION
Adjust max height for thread display and questions list for better UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the active threads section to maintain a fixed height (50% of the viewport) for a consistent display.
  - Adjusted the questions area to occupy the full viewport height on smaller screens and slightly exceed it on larger screens, improving content presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->